### PR TITLE
Release v0.5.2

### DIFF
--- a/.bumper.toml
+++ b/.bumper.toml
@@ -1,5 +1,5 @@
 [tool.bumper]
-current_version = "0.5.1"
+current_version = "0.5.2"
 versioning_type = "semver"
 
 [[tool.bumper.files]]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Versions follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) (`<major>`.`<minor>`.`<patch>`)
 
+## `[v0.5.2]`
+
+### Fixed
+
+* #53 Fix issue with header skipping when ingesting raw log files.
+
 ## `[v0.5.1]`
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # xbmini-py
 
-[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/xbmini-py/0.5.1?logo=python&logoColor=FFD43B)](https://pypi.org/project/xbmini-py/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/xbmini-py/0.5.2?logo=python&logoColor=FFD43B)](https://pypi.org/project/xbmini-py/)
 [![PyPI](https://img.shields.io/pypi/v/xbmini-py)](https://pypi.org/project/xbmini-py/)
 [![PyPI - License](https://img.shields.io/pypi/l/xbmini-py?color=magenta)](https://github.com/sco1/xbmini-py/blob/master/LICENSE)
 [![pre-commit.ci status](https://results.pre-commit.ci/badge/github/sco1/xbmini-py/main.svg)](https://results.pre-commit.ci/latest/github/sco1/xbmini-py/main)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xbmini-py"
-version = "0.5.1"
+version = "0.5.2"
 description = "Python Toolkit for the GCDC HAM"
 license = "MIT"
 license-files = ["LICENSE"]

--- a/uv.lock
+++ b/uv.lock
@@ -1498,7 +1498,7 @@ wheels = [
 
 [[package]]
 name = "xbmini-py"
-version = "0.5.1"
+version = "0.5.2"
 source = { editable = "." }
 dependencies = [
     { name = "matplotlib-window" },

--- a/xbmini/log_parser.py
+++ b/xbmini/log_parser.py
@@ -162,7 +162,7 @@ def load_log(
 
     full_data = pl.read_csv(
         log_filepath,
-        skip_rows=header_info.n_header_lines,
+        skip_lines=header_info.n_header_lines,
         has_header=False,
         new_columns=header_info.header_spec,
         comment_prefix=";",


### PR DESCRIPTION
## `[v0.5.2]`

### Fixed

* #53 Fix issue with header skipping when ingesting raw log files.

Closes: #53